### PR TITLE
Fix argument inputs to list()

### DIFF
--- a/mnist_sequence_cli.py
+++ b/mnist_sequence_cli.py
@@ -6,7 +6,7 @@ import sys
 def main():
     arguments = list(sys.argv[1:])
     if len(arguments) == 4:
-        sequence, min_spacing = list(map(int, list(arguments[0])), int(arguments[1]))
+        sequence, min_spacing = list(map(int, list(arguments[0]))), int(arguments[1])
         max_spacing, image_width = int(arguments[2]), int(arguments[3])
         api_object = MNIST_Sequence_API()
         img_data = api_object.generate_mnist_sequence(sequence, (min_spacing, max_spacing), image_width)


### PR DESCRIPTION
This fixes a runtime issue with using the following command line invocation from the docs:
```
python mnist_sequence_cli.py 01 0 10 66
```

`list()` only takes one argument, but the parentheses were trying to group both the sequence and the min_spacing variables as inputs to `list()`.

Example of error given:
```
Traceback (most recent call last):
  File "mnist_sequence_cli.py", line 20, in <module>
    main()
  File "mnist_sequence_cli.py", line 9, in main
    sequence, min_spacing = list(map(int, list(arguments[0])), int(arguments[1]))
TypeError: list() takes at most 1 argument (2 given)
```